### PR TITLE
feat: add basic stubs for GD 2.2 vehicles

### DIFF
--- a/about.md
+++ b/about.md
@@ -2,8 +2,8 @@
 
 Auto-generate macros for levels using simulation! This mod uses a physics simulator under the hood to solve levels in seconds! It does not come with a bot, you will need to install one for this.
 
-# ONLY SUPPORTS 1.7 LEVELS
-### None of these are supported
+# Supports up to 1.7 level mechanics
+### The following are currently unsupported
 - Duals
 - Upside-down Slopes
 - Partially Rotated Objects (not 90 degrees)
@@ -16,7 +16,7 @@ Auto-generate macros for levels using simulation! This mod uses a physics simula
 - Red Pads / Red Orbs
 - Dash Orbs
 - Teleport Portals
-- Anything from 2.2
+- Many features from 2.2 (work in progress)
 
 # How To Use
 

--- a/gd-sim/include/Vehicle.hpp
+++ b/gd-sim/include/Vehicle.hpp
@@ -3,11 +3,14 @@
 #include <functional>
 
 enum class VehicleType {
-	Cube,
-	Ship,
-	Ball,
-	Ufo,
-	Wave
+        Cube,
+        Ship,
+        Ball,
+        Ufo,
+        Wave,
+        Robot,
+        Spider,
+        Swing
 };
 
 struct Player;

--- a/gd-sim/src/Objects/Object.cpp
+++ b/gd-sim/src/Objects/Object.cpp
@@ -124,7 +124,7 @@ std::optional<ObjectContainer> Object::create(std::unordered_map<int, std::strin
 	objs(({ 67 }), Pad, 25, 6)
 	objs(({ 36, 84, 141 }), Orb, 36, 36)
 
-	objs(({ 12, 13, 47, 111 , 660 }), VehiclePortal, 34, 86)
+        objs(({ 12, 13, 47, 111 , 660, 1331, 1332, 1916 }), VehiclePortal, 34, 86)
 	objs(({ 10, 11 }), GravityPortal, 25, 75)
 
 	objs(({ 99, 101 }), SizePortal, 31, 90)

--- a/gd-sim/src/Objects/Orb.cpp
+++ b/gd-sim/src/Objects/Orb.cpp
@@ -23,8 +23,14 @@ bool Orb::touching(Player const& p) const {
 }
 
 const velocity_map<OrbType, VehicleType, bool> orb_velocities = {
-	{{OrbType::Yellow, VehicleType::Cube, false}, {573.48,      603.72,     616.68,    606.42}},
-	{{OrbType::Yellow, VehicleType::Cube, true},  {458.784,     482.976,    481.734,   485.136}},
+        {{OrbType::Yellow, VehicleType::Cube, false}, {573.48,      603.72,     616.68,    606.42}},
+        {{OrbType::Yellow, VehicleType::Cube, true},  {458.784,     482.976,    481.734,   485.136}},
+        {{OrbType::Yellow, VehicleType::Robot, false}, {573.48,      603.72,     616.68,    606.42}},
+        {{OrbType::Yellow, VehicleType::Robot, true},  {458.784,     482.976,    481.734,   485.136}},
+        {{OrbType::Yellow, VehicleType::Spider, false}, {573.48,      603.72,     616.68,    606.42}},
+        {{OrbType::Yellow, VehicleType::Spider, true},  {458.784,     482.976,    481.734,   485.136}},
+        {{OrbType::Yellow, VehicleType::Swing, false}, {573.48,      603.72,     616.68,    606.42}},
+        {{OrbType::Yellow, VehicleType::Swing, true},  {458.784,     482.976,    481.734,   485.136}},
 
 	{{OrbType::Yellow, VehicleType::Ship, false}, {573.48,      603.72,     616.68,    606.42}},
 	{{OrbType::Yellow, VehicleType::Ship, true},  {458.784,     482.976,    481.734,   485.136}},
@@ -36,8 +42,14 @@ const velocity_map<OrbType, VehicleType, bool> orb_velocities = {
 	{{OrbType::Yellow, VehicleType::Ufo, true},   {458.784,     482.976,    481.734,   485.136}},
 
 
-	{{OrbType::Blue, VehicleType::Cube, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
-	{{OrbType::Blue, VehicleType::Cube, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
+        {{OrbType::Blue, VehicleType::Cube, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
+        {{OrbType::Blue, VehicleType::Cube, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
+        {{OrbType::Blue, VehicleType::Robot, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
+        {{OrbType::Blue, VehicleType::Robot, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
+        {{OrbType::Blue, VehicleType::Spider, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
+        {{OrbType::Blue, VehicleType::Spider, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
+        {{OrbType::Blue, VehicleType::Swing, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
+        {{OrbType::Blue, VehicleType::Swing, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
 
 	{{OrbType::Blue, VehicleType::Ship, false},   {-229.392,    -241.488,   -246.672,  -242.568}},
 	{{OrbType::Blue, VehicleType::Ship, true},    {-183.519,    -193.185,   -197.343,  -194.049}},
@@ -49,8 +61,14 @@ const velocity_map<OrbType, VehicleType, bool> orb_velocities = {
 	{{OrbType::Blue, VehicleType::Ufo, true},     {-183.519,    -193.185,   -197.343,  -194.049}},
 
 
-	{{OrbType::Pink, VehicleType::Cube, false},   {412.884,     434.7,      443.988,   436.644}},
-	{{OrbType::Pink, VehicleType::Cube, true},    {330.318,     347.76,     355.212,   349.272}},
+        {{OrbType::Pink, VehicleType::Cube, false},   {412.884,     434.7,      443.988,   436.644}},
+        {{OrbType::Pink, VehicleType::Cube, true},    {330.318,     347.76,     355.212,   349.272}},
+        {{OrbType::Pink, VehicleType::Robot, false},   {412.884,     434.7,      443.988,   436.644}},
+        {{OrbType::Pink, VehicleType::Robot, true},    {330.318,     347.76,     355.212,   349.272}},
+        {{OrbType::Pink, VehicleType::Spider, false},   {412.884,     434.7,      443.988,   436.644}},
+        {{OrbType::Pink, VehicleType::Spider, true},    {330.318,     347.76,     355.212,   349.272}},
+        {{OrbType::Pink, VehicleType::Swing, false},   {412.884,     434.7,      443.988,   436.644}},
+        {{OrbType::Pink, VehicleType::Swing, true},    {330.318,     347.76,     355.212,   349.272}},
 
 	{{OrbType::Pink, VehicleType::Ship, false},   {212.166,     223.398,    228.15,    224.37}},
 	{{OrbType::Pink, VehicleType::Ship, true},    {169.776,     178.686,    182.52,    179.496}},

--- a/gd-sim/src/Objects/Pad.cpp
+++ b/gd-sim/src/Objects/Pad.cpp
@@ -26,8 +26,14 @@ Pad::Pad(Vec2D size, std::unordered_map<int, std::string>&& fields) : EffectObje
 }
 
 const velocity_map<PadType, VehicleType, bool> pad_velocities = {
-	{{PadType::Yellow, VehicleType::Cube, false}, {864,         864,        864}},
-	{{PadType::Yellow, VehicleType::Cube, true},  {691.2,       691.2,      691.2}},
+        {{PadType::Yellow, VehicleType::Cube, false}, {864,         864,        864}},
+        {{PadType::Yellow, VehicleType::Cube, true},  {691.2,       691.2,      691.2}},
+        {{PadType::Yellow, VehicleType::Robot, false}, {864,         864,        864}},
+        {{PadType::Yellow, VehicleType::Robot, true},  {691.2,       691.2,      691.2}},
+        {{PadType::Yellow, VehicleType::Spider, false}, {864,         864,        864}},
+        {{PadType::Yellow, VehicleType::Spider, true},  {691.2,       691.2,      691.2}},
+        {{PadType::Yellow, VehicleType::Swing, false}, {864,         864,        864}},
+        {{PadType::Yellow, VehicleType::Swing, true},  {691.2,       691.2,      691.2}},
 
 	{{PadType::Yellow, VehicleType::Ship, false}, {432,         432,        432}},
 	{{PadType::Yellow, VehicleType::Ship, true},  {691.2,       691.2,      691.2}},
@@ -39,8 +45,14 @@ const velocity_map<PadType, VehicleType, bool> pad_velocities = {
 	{{PadType::Yellow, VehicleType::Ufo, true},   {458.784,     691.2,      691.2}},
 
 
-	{{PadType::Blue, VehicleType::Cube, false},   {-345.6,    -345.6,     -345.6}},
-	{{PadType::Blue, VehicleType::Cube, true},    {-276.48,    -276.48,    -276.48}},
+        {{PadType::Blue, VehicleType::Cube, false},   {-345.6,    -345.6,     -345.6}},
+        {{PadType::Blue, VehicleType::Cube, true},    {-276.48,    -276.48,    -276.48}},
+        {{PadType::Blue, VehicleType::Robot, false},   {-345.6,    -345.6,     -345.6}},
+        {{PadType::Blue, VehicleType::Robot, true},    {-276.48,    -276.48,    -276.48}},
+        {{PadType::Blue, VehicleType::Spider, false},   {-345.6,    -345.6,     -345.6}},
+        {{PadType::Blue, VehicleType::Spider, true},    {-276.48,    -276.48,    -276.48}},
+        {{PadType::Blue, VehicleType::Swing, false},   {-345.6,    -345.6,     -345.6}},
+        {{PadType::Blue, VehicleType::Swing, true},    {-276.48,    -276.48,    -276.48}},
 
 	{{PadType::Blue, VehicleType::Ship, false},   {-229.392,    -345.6,     -345.6}},
 	{{PadType::Blue, VehicleType::Ship, true},    {-183.519,    -276.48,    -276.48}},
@@ -52,8 +64,14 @@ const velocity_map<PadType, VehicleType, bool> pad_velocities = {
 	{{PadType::Blue, VehicleType::Ufo, true},     {-183.519,    -276.48,    -276.48}},
 
 
-	{{PadType::Pink, VehicleType::Cube, false},   {561.6,       561.6,      561.6}},
-	{{PadType::Pink, VehicleType::Cube, true},    {449.28,      449.28,     449.28}},
+        {{PadType::Pink, VehicleType::Cube, false},   {561.6,       561.6,      561.6}},
+        {{PadType::Pink, VehicleType::Cube, true},    {449.28,      449.28,     449.28}},
+        {{PadType::Pink, VehicleType::Robot, false},   {561.6,       561.6,      561.6}},
+        {{PadType::Pink, VehicleType::Robot, true},    {449.28,      449.28,     449.28}},
+        {{PadType::Pink, VehicleType::Spider, false},   {561.6,       561.6,      561.6}},
+        {{PadType::Pink, VehicleType::Spider, true},    {449.28,      449.28,     449.28}},
+        {{PadType::Pink, VehicleType::Swing, false},   {561.6,       561.6,      561.6}},
+        {{PadType::Pink, VehicleType::Swing, true},    {449.28,      449.28,     449.28}},
 
 	{{PadType::Pink, VehicleType::Ship, false},   {302.4,       302.4,      302.4}},
 	{{PadType::Pink, VehicleType::Ship, true},    {241.92,      241.92,     241.92}},

--- a/gd-sim/src/Objects/VehiclePortal.cpp
+++ b/gd-sim/src/Objects/VehiclePortal.cpp
@@ -2,26 +2,36 @@
 #include <Player.hpp>
 
 VehiclePortal::VehiclePortal(Vec2D size, std::unordered_map<int, std::string>&& fields) : EffectObject(size, std::move(fields)) {
-	switch (atoi(fields[1].c_str())) {
-		case 12:
-			type = VehicleType::Cube;
-			break;
-		case 13:
-			type = VehicleType::Ship;
-			break;
-		case 47:
-			type = VehicleType::Ball;
-			break;
-		case 111:
-			type = VehicleType::Ufo;
-			break;
-		case 660:
-			type = VehicleType::Wave;
-			break;
-		default:
-			type = VehicleType::Cube;
-			break;
-		}
+        switch (atoi(fields[1].c_str())) {
+                case 12:
+                        type = VehicleType::Cube;
+                        break;
+                case 13:
+                        type = VehicleType::Ship;
+                        break;
+                case 47:
+                        type = VehicleType::Ball;
+                        break;
+                case 111:
+                        type = VehicleType::Ufo;
+                        break;
+                case 660:
+                        type = VehicleType::Wave;
+                        break;
+                // TODO: verify correct IDs for new 2.2 vehicles
+                case 1331:
+                        type = VehicleType::Robot;
+                        break;
+                case 1332:
+                        type = VehicleType::Spider;
+                        break;
+                case 1916:
+                        type = VehicleType::Swing;
+                        break;
+                default:
+                        type = VehicleType::Cube;
+                        break;
+                }
 }
 
 void VehiclePortal::collide(Player& player) const {

--- a/gd-sim/src/Vehicle.cpp
+++ b/gd-sim/src/Vehicle.cpp
@@ -322,17 +322,41 @@ Vehicle wave() {
 	return v;
 }
 
+Vehicle robot() {
+        auto v = cube();
+        v.type = VehicleType::Robot;
+        return v;
+}
+
+Vehicle spider() {
+        auto v = cube();
+        v.type = VehicleType::Spider;
+        return v;
+}
+
+Vehicle swing() {
+        auto v = wave();
+        v.type = VehicleType::Swing;
+        return v;
+}
+
 Vehicle Vehicle::from(VehicleType v) {
-	switch (v) {
-		case VehicleType::Cube:
-			return cube();
-		case VehicleType::Ship:
-			return ship();
-		case VehicleType::Ball:
-			return ball();
-		case VehicleType::Ufo:
-			return ufo();
-		case VehicleType::Wave:
-			return wave();
-	}
+        switch (v) {
+                case VehicleType::Cube:
+                        return cube();
+                case VehicleType::Ship:
+                        return ship();
+                case VehicleType::Ball:
+                        return ball();
+                case VehicleType::Ufo:
+                        return ufo();
+                case VehicleType::Wave:
+                        return wave();
+                case VehicleType::Robot:
+                        return robot();
+                case VehicleType::Spider:
+                        return spider();
+                case VehicleType::Swing:
+                        return swing();
+        }
 }


### PR DESCRIPTION
## Summary
- stub Robot, Spider, and Swing vehicles for upcoming Geometry Dash 2.2 support
- recognize new vehicle portal IDs and supply placeholder pad/orb velocities
- document 2.2 feature support as a work in progress

## Testing
- `cmake -S gd-sim -B gd-sim/build`
- `cmake --build gd-sim/build` *(fails: std::unordered_set missing `contains`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f182c920832aa57aa56a1896bf2c