### PR TITLE
Add basic teleport portal support

### DIFF
--- a/about.md
+++ b/about.md
@@ -8,7 +8,6 @@ Auto-generate macros for levels using simulation! This mod uses a physics simula
 - Upside-down Slopes
 - Partially Rotated Objects (not 90 degrees)
 - Any Non-Visual Triggers
-- Teleport Portals
 
 # How To Use
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# beta 20
+
+- Add basic support for teleport portals
+
 # beta 19
 
 - Fix ship accelerations

--- a/gd-sim/CMakeLists.txt
+++ b/gd-sim/CMakeLists.txt
@@ -16,3 +16,4 @@ add_executable(gd-sim-test ${SOURCES} test/test.cpp)
 
 set_target_properties(gd-sim-test PROPERTIES INTERPROCEDURAL_OPTIMIZATION 0)
 target_include_directories(gd-sim-test PRIVATE include)
+target_compile_features(gd-sim-test PRIVATE cxx_std_20)

--- a/gd-sim/include/Portals.hpp
+++ b/gd-sim/include/Portals.hpp
@@ -25,3 +25,10 @@ struct SpeedPortal : public EffectObject {
     SpeedPortal(Vec2D size, std::unordered_map<int, std::string>&& fields);
     void collide(Player&) const override;
 };
+
+struct TeleportPortal : public EffectObject {
+    int group;
+    TeleportPortal* target;
+    TeleportPortal(Vec2D size, std::unordered_map<int, std::string>&& fields);
+    void collide(Player&) const override;
+};

--- a/gd-sim/src/Objects/Object.cpp
+++ b/gd-sim/src/Objects/Object.cpp
@@ -125,11 +125,12 @@ std::optional<ObjectContainer> Object::create(std::unordered_map<int, std::strin
 	objs(({ 36, 84, 141 }), Orb, 36, 36)
 
         objs(({ 12, 13, 47, 111 , 660, 1331, 1332, 1916 }), VehiclePortal, 34, 86)
-	objs(({ 10, 11 }), GravityPortal, 25, 75)
+        objs(({ 10, 11 }), GravityPortal, 25, 75)
 
-	objs(({ 99, 101 }), SizePortal, 31, 90)
+        objs(({ 99, 101 }), SizePortal, 31, 90)
+        objs(({ 747 }), TeleportPortal, 31, 90)
 
-	objs(({ 143 }), BreakableBlock, 30, 30)
+        objs(({ 143 }), BreakableBlock, 30, 30)
 
 	objs(({ 200 }), SpeedPortal, 35, 44)
 	objs(({ 201 }), SpeedPortal, 33, 56)

--- a/gd-sim/src/Objects/TeleportPortal.cpp
+++ b/gd-sim/src/Objects/TeleportPortal.cpp
@@ -1,0 +1,27 @@
+#include <Portals.hpp>
+#include <Player.hpp>
+#include <unordered_map>
+
+static std::unordered_map<int, TeleportPortal*> s_portalPairs;
+
+TeleportPortal::TeleportPortal(Vec2D size, std::unordered_map<int, std::string>&& fields)
+    : EffectObject(size, std::move(fields)), group(0), target(nullptr) {
+    auto it = fields.find(28);
+    if (it != fields.end()) {
+        group = std::stoi(it->second);
+        auto it2 = s_portalPairs.find(group);
+        if (it2 == s_portalPairs.end()) {
+            s_portalPairs[group] = this;
+        } else {
+            target = it2->second;
+            it2->second->target = this;
+        }
+    }
+}
+
+void TeleportPortal::collide(Player& p) const {
+    EffectObject::collide(p);
+    if (target) {
+        p.pos = target->pos;
+    }
+}


### PR DESCRIPTION
## Summary
- add TeleportPortal object to simulator
- hook up teleport portal creation
- document teleport portal support

## Testing
- `cmake -S gd-sim -B build/gd-sim`
- `cmake --build build/gd-sim`
- `./build/gd-sim/gd-sim-test` *(fails: Must be used by mod)*
