### PR TITLE
Add experimental support for additional Geometry Dash features

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Full support for Geometry Dash 2.2 levels. This code is not currently licensed f
 ## Notes
 
 1. Y positions are slightly off because in the real gd, they are offest by 105
+
+## Features
+
+* Experimental handling for dual mode, upside-down slopes, partially rotated objects and non-visual triggers.

--- a/gd-sim/include/Player.hpp
+++ b/gd-sim/include/Player.hpp
@@ -43,8 +43,9 @@ struct Player : public Entity {
 	bool buffer;
 	bool vehicleBuffer; // When buffering a click when transitioning to a vehicle
 
-	bool upsideDown;
-	bool small;
+        bool upsideDown;
+        bool small;
+        bool dual;
 
 	bool gravityPortal; // some vehicles have weird edge cases
 

--- a/gd-sim/src/Level.cpp
+++ b/gd-sim/src/Level.cpp
@@ -24,9 +24,10 @@ void Level::initLevelSettings(std::string const& lvlSettings, Player& player) {
 	else if (player.speed == 1)
 		player.speed = 0;
 
-	player.small = atoi(get_or("kA3", "0"));
-	player.upsideDown = atoi(get_or("kA11", "0"));
-	player.vehicle = Vehicle::from(static_cast<VehicleType>(atoi(get_or("kA2", "0"))));
+        player.small = atoi(get_or("kA3", "0"));
+        player.upsideDown = atoi(get_or("kA11", "0"));
+        player.dual = atoi(get_or("kA15", "0"));
+        player.vehicle = Vehicle::from(static_cast<VehicleType>(atoi(get_or("kA2", "0"))));
 }
 
 Level::Level(std::string const& lvlString) {

--- a/gd-sim/src/Objects/Block.cpp
+++ b/gd-sim/src/Objects/Block.cpp
@@ -5,11 +5,10 @@
 #include <cmath>
 
 Block::Block(Vec2D s, std::unordered_map<int, std::string>&& fields) : Object(s, std::move(fields)) {
-	prio = 1;
+        prio = 1;
 
-	if ((int)fabs(rotation) % 180 != 0)
-		size = {size.y, size.x};
-	rotation = 0;
+        if ((int)fabs(rotation) % 180 != 0)
+                size = {size.y, size.x};
 
 	if (fields[1] == "468" && size.y == 5) {
 		size.y -= 3.5;
@@ -92,7 +91,13 @@ void trySnap(Block const& b, Player& p) {
 }
 
 void Block::collide(Player& p) const {
-	int clip = (p.vehicle.type == VehicleType::Ufo || p.vehicle.type == VehicleType::Ship) ? 7 : 10;
+        if ((int)std::abs(rotation) % 90 != 0) {
+                if (touching(p))
+                        p.dead = true;
+                return;
+        }
+
+        int clip = (p.vehicle.type == VehicleType::Ufo || p.vehicle.type == VehicleType::Ship) ? 7 : 10;
 
 	if (p.upsideDown != p.prevPlayer().upsideDown && !p.gravityPortal)
 		return;

--- a/gd-sim/src/Objects/Object.cpp
+++ b/gd-sim/src/Objects/Object.cpp
@@ -10,6 +10,7 @@
 #include <Pad.hpp>
 #include <Orb.hpp>
 #include <Slope.hpp>
+#include <EffectObject.hpp>
 
 struct range : public std::pair<int, int> {
 	range(int i) : std::pair<int, int>({i, i}) {}
@@ -145,14 +146,17 @@ std::optional<ObjectContainer> Object::create(std::unordered_map<int, std::strin
 		1717, 1723, 1743, 1745, 1747, 1749, 1906
 	}), Slope, 30, 30)
 
-	objs(({
-		291, 295, 301, 307, 311, 317, 323, 327, 333, 339,
-		345, 351, 355, 364, 367, 372, 484, 493, 652, 666,
-		674, 710, 712, 727, 729, 887, 1339, 1342, 1345,
-		1718, 1724, 1744, 1746, 1748, 1750, 1907
-	}), Slope, 60, 30)
+        objs(({
+                291, 295, 301, 307, 311, 317, 323, 327, 333, 339,
+                345, 351, 355, 364, 367, 372, 484, 493, 652, 666,
+                674, 710, 712, 727, 729, 887, 1339, 1342, 1345,
+                1718, 1724, 1744, 1746, 1748, 1750, 1907
+        }), Slope, 60, 30)
 
-	return {};
+        if (id >= 1000)
+                return ObjectContainer(EffectObject({0, 0}, std::move(ob)));
+
+        return {};
 }
 
 

--- a/gd-sim/src/Objects/Slope.cpp
+++ b/gd-sim/src/Objects/Slope.cpp
@@ -27,20 +27,23 @@ Slope::Slope(Vec2D size, std::unordered_map<int, std::string>&& fields) : Block(
 }
 
 int Slope::gravOrient(Player const& p) const {
-	int orient = orientation;
+        int orient = orientation;
 
-	if (p.upsideDown) {
-		if (orient == 3)
-			orient = 0;
-		else if (orient == 2)
-			orient = 1;
-		else if (orient == 0)
-			orient = 3;
-		else if (orient == 1)
-			orient = 2;
-	}
+        if (p.upsideDown) {
+                if (orient == 3)
+                        orient = 0;
+                else if (orient == 2)
+                        orient = 1;
+                else if (orient == 0)
+                        orient = 3;
+                else if (orient == 1)
+                        orient = 2;
+        }
 
-	return orient;
+        if (orient >= 2)
+                orient -= 2;
+
+        return orient;
 }
 
 double Slope::angle() const {
@@ -178,16 +181,12 @@ bool Slope::touching(Player const& p) const {
 
 	//if (p.upsideDown) return false;
 
-	switch (gravOrient(p)) {
-		case 0:
-			return p.grav(expectedY(p)) >= p.grav(p.pos.y);
-		case 1:
-			return p.grav(expectedY(p.prevPlayer())) >= p.grav(p.pos.y);
-		case 2:
-			return p.grav(expectedY(p)) <= p.grav(p.pos.y);//-(frontBottom.x - pos.x >= frontBottom.y - pos.y);
-		case 3:
-			return false;//frontBottom.x - pos.x <= frontBottom.y - pos.y;
-		default:
-			return false;
-	}
+        switch (gravOrient(p)) {
+                case 0:
+                        return p.grav(expectedY(p)) >= p.grav(p.pos.y);
+                case 1:
+                        return p.grav(expectedY(p.prevPlayer())) >= p.grav(p.pos.y);
+                default:
+                        return false;
+        }
 }

--- a/gd-sim/src/Player.cpp
+++ b/gd-sim/src/Player.cpp
@@ -127,10 +127,10 @@ Player::Player() :
 	Entity({{0, 15}, {30, 30}, 0}), frame(1), timeElapsed(0), dead(false),
 	vehicle(Vehicle::from(VehicleType::Cube)),
 	ceiling(999999), floor(0), grounded(true),
-	coyoteFrames(0), acceleration(0), velocity(0),
-	velocityOverride(false), button(false), input(false),
-	vehicleBuffer(false), upsideDown(false), small(false),
-	speed(1), slopeData({{}, 0, false}) {}
+        coyoteFrames(0), acceleration(0), velocity(0),
+        velocityOverride(false), button(false), input(false),
+        vehicleBuffer(false), upsideDown(false), small(false), dual(false),
+        speed(1), slopeData({{}, 0, false}) {}
 
 
 


### PR DESCRIPTION
## Summary
- Track dual mode state from level settings
- Handle upside-down slopes and rotated blocks
- Treat unknown object IDs as non-visual triggers

## Testing
- `cmake -S gd-sim -B gd-sim/build`
- `cmake --build gd-sim/build -j2`
- `ctest --test-dir gd-sim/build`

