### PR TITLE
Fix build issues on Windows

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,6 +1,14 @@
 #include <Geode/Geode.hpp>
 #include <UIBuilder.hpp>
 
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <vector>
+
 using namespace geode::prelude;
 using namespace geode::utils::file;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,9 @@
 #include <Geode/modify/LevelInfoLayer.hpp>
 #include <UIBuilder.hpp>
 #include "pathfinder.hpp"
+#include <chrono>
 #include <future>
+#include <unordered_set>
 
 using namespace geode::prelude;
 using namespace geode::utils::file;

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <set>
 #include <Level.hpp>
 #include <random>

--- a/src/pathfinder.hpp
+++ b/src/pathfinder.hpp
@@ -1,5 +1,17 @@
-#include <atomic>
-#include <string>
-#include <functional>
+// Prevent multiple inclusion of this header
+#pragma once
 
-std::vector<uint8_t> pathfind(std::string const& lvlString, std::atomic_bool& stop, std::function<void(double)> callback);
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+// Runs the pathfinding algorithm on the provided level string.  The
+// callback is periodically invoked with the progress percentage.  The
+// operation can be cancelled via the `stop` flag.  The result is a
+// serialized replay in the GDR format.
+std::vector<uint8_t> pathfind(
+    std::string const& lvlString,
+    std::atomic_bool& stop,
+    std::function<void(double)> callback);


### PR DESCRIPTION
## Summary
- add missing header guard and required includes
- include algorithms and chrono support across sources
- ensure debug utilities include standard library headers

## Testing
- `cmake -S . -B build && cmake --build build` *(fails: Unable to find Geode SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68a7fd1782c0832ab4a6222325ab337b