### PR TITLE
Fix Windows build errors

### DIFF
--- a/gd-sim/include/Level.hpp
+++ b/gd-sim/include/Level.hpp
@@ -2,6 +2,7 @@
 #include <Object.hpp>
 #include <Player.hpp>
 #include <vector>
+#include <cstdint>
 
 class Level {
 	void initLevelSettings(std::string const& lvlSettings, Player& player);

--- a/gd-sim/include/util.hpp
+++ b/gd-sim/include/util.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <utility>
 #include <string>
+#include <cstdint>
 
 #include <vector>
 #include <unordered_set>

--- a/src/pathfinder.cpp
+++ b/src/pathfinder.cpp
@@ -1,4 +1,5 @@
 #include <set>
+#include <cstdint>
 #include <Level.hpp>
 #include <random>
 #include <gdr/gdr.hpp>
@@ -40,9 +41,9 @@ int tryInputs(Level2& lvl, std::set<uint16_t> inputs) {
 
 		lvl.runFrame(lvl.press);
 	}
-	int final = lvl.currentFrame();
-	float lastX = lvl.latestFrame().pos.y;
-	float lastY = lvl.latestFrame().pos.y;
+        int final = lvl.currentFrame();
+        float lastX = lvl.latestFrame().pos.x;
+        float lastY = lvl.latestFrame().pos.y;
 
 	lvl.rollback(frame);
 	lvl.press = press_before;


### PR DESCRIPTION
## Summary
- include `<cstdint>` where fixed-size integer types are used
- correct X coordinate lookup in pathfinding routine

## Testing
- `cmake --build build_gdsim --target gd-sim`
- `cmake --build build_gdsim --target gd-sim-test`


